### PR TITLE
Add reusable back/home buttons

### DIFF
--- a/src/components/BackHomeButtons.tsx
+++ b/src/components/BackHomeButtons.tsx
@@ -1,0 +1,26 @@
+import { Link, useNavigate } from "react-router-dom";
+import { ArrowLeft, Home as HomeIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+const BackHomeButtons = () => {
+  const navigate = useNavigate();
+  return (
+    <div className="flex gap-2">
+      <Button
+        variant="ghost"
+        className="flex items-center gap-1 text-anny-green hover:text-anny-green/90"
+        onClick={() => navigate(-1)}
+      >
+        <ArrowLeft className="w-4 h-4" />
+        Voltar
+      </Button>
+      <Button asChild variant="ghost" className="flex items-center gap-1 text-anny-green hover:text-anny-green/90">
+        <Link to="/home">
+          <HomeIcon className="w-4 h-4" /> Home
+        </Link>
+      </Button>
+    </div>
+  );
+};
+
+export default BackHomeButtons;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { ChatDialog } from "./ChatDialog";
 import { MessageCircle } from "lucide-react";
 import NotificationsDialog from "./NotificationsDialog";
 import AccessibilityControls from "./AccessibilityControls";
+import BackHomeButtons from "./BackHomeButtons";
 
 const Header = () => {
   const [cartItemCount, setCartItemCount] = useState(0);
@@ -46,6 +47,7 @@ const Header = () => {
         </div>
       </Link>
       <div className="flex items-center gap-1 md:gap-4">
+        <BackHomeButtons />
         <AccessibilityControls />
         <NotificationsDialog />
         <CartSheet />

--- a/src/pages/AboutUsPage.tsx
+++ b/src/pages/AboutUsPage.tsx
@@ -1,5 +1,6 @@
 
 import React from "react";
+import BackHomeButtons from "@/components/BackHomeButtons";
 import { 
   Accordion, 
   AccordionContent, 
@@ -10,7 +11,8 @@ import { Separator } from "@/components/ui/separator";
 
 const AboutUsPage = () => {
   return (
-    <div className="max-w-4xl mx-auto py-6">
+    <div className="max-w-4xl mx-auto py-6 space-y-4">
+      <BackHomeButtons />
       <h1 className="text-3xl font-bold text-center text-anny-green mb-6">Sobre o Projeto Anny</h1>
       
       <div className="flex flex-col md:flex-row gap-8 items-center mb-8">

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Calendar, User } from "lucide-react";
+import { Calendar, User } from "lucide-react";
 
 interface BlogPost {
   id: number;
@@ -63,14 +63,6 @@ const BlogPage = () => {
 
   return (
     <div className="space-y-6">
-      <Button
-        variant="ghost"
-        className="flex items-center gap-2 text-anny-green hover:text-anny-green/90"
-        onClick={() => navigate(-1)}
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Voltar
-      </Button>
 
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
         <h1 className="text-2xl md:text-3xl font-bold">Blog de Saúde</h1>

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -1,7 +1,7 @@
 
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { ShoppingCart, Trash2, ChevronLeft, MinusCircle, PlusCircle, Ticket } from "lucide-react";
+import { ShoppingCart, Trash2, MinusCircle, PlusCircle, Ticket } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
@@ -56,13 +56,6 @@ export default function CartPage() {
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="flex items-center gap-3 mb-8">
-        <Button 
-          variant="ghost" 
-          className="p-0" 
-          onClick={() => navigate(-1)}
-        >
-          <ChevronLeft className="h-5 w-5" />
-        </Button>
         <h1 className="text-2xl md:text-3xl font-bold flex items-center gap-3">
           <ShoppingCart className="h-7 w-7" />
           Carrinho de Compras

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Mail } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import BackHomeButtons from "@/components/BackHomeButtons";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -50,7 +51,8 @@ const ContactPage = () => {
       setIsSubmitting(false);
     }
   };
-  return <div className="max-w-4xl mx-auto py-6">
+  return <div className="max-w-4xl mx-auto py-6 space-y-4">
+      <BackHomeButtons />
       <h1 className="text-3xl font-bold text-center text-anny-green mb-6">Entre em Contato</h1>
       <p className="text-center text-gray-700 mb-8">
         Estamos aqui para ajudar! Preencha o formulário abaixo ou utilize nosso e-mail de contato.

--- a/src/pages/DoctorsPage.tsx
+++ b/src/pages/DoctorsPage.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Star, Calendar, MapPin } from "lucide-react";
+import { Star, Calendar, MapPin } from "lucide-react";
 import { debouncedToast } from "@/components/ui/sonner";
 
 interface Doctor {
@@ -73,15 +73,6 @@ const DoctorsPage = () => {
 
   return (
     <div className="space-y-6">
-      <Button
-        variant="ghost"
-        className="flex items-center gap-2 text-anny-green hover:text-anny-green/90"
-        onClick={() => navigate(-1)}
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Voltar
-      </Button>
-
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
         <h1 className="text-2xl md:text-3xl font-bold">Médicos e Especialistas</h1>
         

--- a/src/pages/ExamDetailsPage.tsx
+++ b/src/pages/ExamDetailsPage.tsx
@@ -1,6 +1,5 @@
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "lucide-react";
 
 const ExamDetailsPage = () => {
   const navigate = useNavigate();
@@ -12,16 +11,7 @@ const ExamDetailsPage = () => {
   if (!examDetails) {
     return (
       <div className="space-y-6">
-        <Button
-          variant="ghost"
-          className="flex items-center gap-2 text-anny-green hover:text-anny-green/90"
-          onClick={() => navigate(-1)}
-        >
-          <ArrowLeft className="w-4 h-4" />
-          Voltar
-        </Button>
-
-        <div className="text-center py-12">
+      <div className="text-center py-12">
           <h3 className="text-lg font-medium text-gray-900">Exame não encontrado</h3>
           <p className="mt-2 text-sm text-gray-500">
             Não foi possível encontrar os detalhes deste exame.
@@ -39,15 +29,6 @@ const ExamDetailsPage = () => {
 
   return (
     <div className="space-y-6">
-      <Button
-        variant="ghost"
-        className="flex items-center gap-2 text-anny-green hover:text-anny-green/90"
-        onClick={() => navigate(-1)}
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Voltar
-      </Button>
-
       <div className="anny-card">
         <h1 className="text-2xl font-bold mb-6">Detalhes do Exame #{id}</h1>
         

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/accordion";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Search, Mail, Phone, MessageSquare } from "lucide-react";
+import BackHomeButtons from "@/components/BackHomeButtons";
 
 interface FAQItem {
   id: string;
@@ -109,7 +110,8 @@ const FAQPage = () => {
   const categories = ["todos", "produtos", "pagamento", "envio", "legal", "devolucoes"];
   
   return (
-    <div className="max-w-4xl mx-auto py-6">
+    <div className="max-w-4xl mx-auto py-6 space-y-4">
+      <BackHomeButtons />
       <h1 className="text-3xl font-bold text-center text-anny-green mb-6">Perguntas Frequentes</h1>
       <p className="text-center text-gray-700 mb-8">
         Encontre respostas rápidas para as dúvidas mais comuns sobre nossos produtos e serviços.

--- a/src/pages/FavoritesPage.tsx
+++ b/src/pages/FavoritesPage.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Heart, ShoppingCart, Trash2 } from "lucide-react";
+import { Heart, ShoppingCart, Trash2 } from "lucide-react";
 import { debouncedToast } from "@/components/ui/sonner";
 import { Link } from "react-router-dom";
 
@@ -78,14 +78,6 @@ const FavoritesPage = () => {
 
   return (
     <div className="space-y-6">
-      <Button
-        variant="ghost"
-        className="flex items-center gap-2 text-anny-green hover:text-anny-green/90"
-        onClick={() => navigate(-1)}
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Voltar
-      </Button>
 
       <div className="flex items-center gap-3">
         <Heart className="w-6 h-6 text-red-500 fill-red-500" />

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "lucide-react";
 
 const HistoryPage = () => {
   const navigate = useNavigate();
@@ -11,14 +10,6 @@ const HistoryPage = () => {
 
   return (
     <div className="space-y-6">
-      <Button
-        variant="ghost"
-        className="flex items-center gap-2 text-anny-green hover:text-anny-green/90"
-        onClick={() => navigate(-1)}
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Voltar
-      </Button>
 
       <h1 className="text-2xl md:text-3xl font-bold">Histórico de Exames</h1>
 

--- a/src/pages/OrdersPage.tsx
+++ b/src/pages/OrdersPage.tsx
@@ -1,7 +1,7 @@
 
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, ShoppingCart, Package, Truck, MapPin } from "lucide-react";
+import { ShoppingCart, Package, Truck, MapPin } from "lucide-react";
 
 const OrdersPage = () => {
   const navigate = useNavigate();
@@ -12,14 +12,6 @@ const OrdersPage = () => {
 
   return (
     <div className="space-y-6">
-      <Button
-        variant="ghost"
-        className="flex items-center gap-2 text-anny-green hover:text-anny-green/90"
-        onClick={() => navigate(-1)}
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Voltar
-      </Button>
 
       <h1 className="text-2xl md:text-3xl font-bold">Meus Pedidos</h1>
 

--- a/src/pages/PoliciesPage.tsx
+++ b/src/pages/PoliciesPage.tsx
@@ -8,12 +8,14 @@ import {
   CollapsibleTrigger
 } from "@/components/ui/collapsible";
 import { ChevronDown } from "lucide-react";
+import BackHomeButtons from "@/components/BackHomeButtons";
 
 const PoliciesPage = () => {
   const [activeTab, setActiveTab] = useState("privacy");
   
   return (
-    <div className="max-w-4xl mx-auto py-6">
+    <div className="max-w-4xl mx-auto py-6 space-y-4">
+      <BackHomeButtons />
       <h1 className="text-3xl font-bold text-center text-anny-green mb-6">Políticas e Termos</h1>
       <p className="text-center text-gray-700 mb-8">
         Conheça nossas políticas e termos de uso da plataforma. Ao utilizar nossos serviços,

--- a/src/pages/PromotionsPage.tsx
+++ b/src/pages/PromotionsPage.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, ShoppingCart, Tag, Clock, Percent } from "lucide-react";
+import { ShoppingCart, Tag, Clock, Percent } from "lucide-react";
 import { debouncedToast } from "@/components/ui/sonner";
 import { Link } from "react-router-dom";
 
@@ -125,14 +125,6 @@ const PromotionsPage = () => {
 
   return (
     <div className="space-y-6">
-      <Button
-        variant="ghost"
-        className="flex items-center gap-2 text-anny-green hover:text-anny-green/90"
-        onClick={() => navigate(-1)}
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Voltar
-      </Button>
 
       <div className="flex items-center gap-3">
         <Tag className="w-6 h-6 text-anny-orange" />


### PR DESCRIPTION
## Summary
- add `<BackHomeButtons>` component for back/home navigation
- use the new component in `Header` for all layout pages
- show back/home buttons on About, Contact, FAQ and Policies pages
- remove inline back buttons from pages now covered by the header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68547e34dc848333a4e31d13341e4bf8